### PR TITLE
fix: enhance record fetching with new ID resolution logic

### DIFF
--- a/client.go
+++ b/client.go
@@ -2,6 +2,7 @@ package tencentcloud
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"strings"
 	"sync"
@@ -129,4 +130,18 @@ func (p *Provider) deleteRecord(ctx context.Context, zone string, record libdns.
 		return err
 	}
 	return nil
+}
+
+// getRecordIdByNameAndType gets the record id by name and type
+func (p *Provider) getRecordIdByNameAndType(ctx context.Context, zone, recName, recType string) (string, error) {
+	records, err := p.GetRecords(ctx, zone)
+	if err != nil {
+		return "", err
+	}
+	for _, record := range records {
+		if record.Name == recName && record.Type == recType {
+			return record.ID, nil
+		}
+	}
+	return "", fmt.Errorf("record %q not found", recName)
 }

--- a/dnspod/client.go
+++ b/dnspod/client.go
@@ -17,6 +17,7 @@ package dnspod
 import (
 	"context"
 	"errors"
+
 	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common"
 	tchttp "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http"
 	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/profile"

--- a/provider.go
+++ b/provider.go
@@ -34,6 +34,13 @@ func (p *Provider) AppendRecords(ctx context.Context, zone string, records []lib
 // SetRecords sets the records for a zone
 func (p *Provider) SetRecords(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
 	for i, record := range records {
+		// If record is is empty try to get the record id by name and type
+		if record.ID == "" {
+			id, err := p.getRecordIdByNameAndType(ctx, zone, record.Name, record.Type)
+			if err == nil {
+				record.ID = id
+			}
+		}
 		if record.ID == "" {
 			newRecord, err := p.AppendRecords(ctx, zone, []libdns.Record{record})
 			if err != nil {


### PR DESCRIPTION
- Add a new function to get record ID by name and type in the provider
- Modify the SetRecords function to attempt fetching record ID by name and type if the record ID is empty

Signed-off-by: ysicing <i@ysicing.me>

#caddy-dns/tencentcloud#11